### PR TITLE
Don't verify the SSL cert of the hypothesis API

### DIFF
--- a/hypothesis.py
+++ b/hypothesis.py
@@ -33,8 +33,12 @@ class HypothesisClient(object):
                 'email': email,
                 }
 
-        rsp = requests.post('{}/api/users'.format(self.service),
-                            data=json.dumps(data), auth=auth)
+        rsp = requests.post(
+            '{}/api/users'.format(self.service),
+            data=json.dumps(data),
+            auth=auth,
+            # Don't verify SSL certificates if posting to localhost.
+            verify=urlparse(self.service).hostname != 'localhost')
         rsp.raise_for_status()
 
     def grant_token(self, username):


### PR DESCRIPTION
There's no point in this example app doing SSL verification, and if the
development instance of h is running over SSL [1] then SSL verification will
fail and crash. So simply disable SSL verification so that the example
publisher account site can work with dev h over SSL.

[1]: http://h.readthedocs.io/en/latest/developing/ssl/