### PR TITLE
Add FLASK_HOST environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 FLASK_PORT=5050
 
+ifndef FLASK_HOST
+FLASK_HOST = 127.0.0.1
+endif
+
 .PHONY: run
 run:
 	export FLASK_APP=app.py; \
 	export FLASK_DEBUG=1; \
-	flask run --port $(FLASK_PORT)
+	flask run --port $(FLASK_PORT) --host $(FLASK_HOST)
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Allows you to run it on 0.0.0.0 so that you can test it on a mobile
device, for example.