### PR TITLE
Set a shorter expiry on the grant token

### DIFF
--- a/hypothesis.py
+++ b/hypothesis.py
@@ -55,6 +55,6 @@ class HypothesisClient(object):
             'iss': self.client_id,
             'sub': 'acct:{}@{}'.format(username, self.authority),
             'nbf': now,
-            'exp': now + datetime.timedelta(minutes=30),
+            'exp': now + datetime.timedelta(minutes=5),
         }
         return jwt.encode(claims, self.client_secret, algorithm='HS256')


### PR DESCRIPTION
We [limited the maximum lifetime of grant tokens in the service][1], so that compromised grant tokens could only be useful for a limited time. This shortens the expiry time to fit within that window.

[1]: https://github.com/hypothesis/h/pull/4381