### PR TITLE
Enable SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,7 @@ endif
 
 .PHONY: run
 run:
-	export FLASK_APP=app.py; \
-	export FLASK_DEBUG=1; \
-	flask run --port $(FLASK_PORT) --host $(FLASK_HOST)
+	./app.py
 
 .PHONY: lint
 lint:

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 
 from flask import Flask, redirect, render_template, request, session, url_for
@@ -61,3 +62,15 @@ def index():
                            grant_token=grant_token,
                            username=username,
                            service_url=hypothesis_service)
+
+
+if __name__ == '__main__':
+    def ssl_context():
+        if 'FLASK_SSL' in os.environ:
+            return 'adhoc'
+
+    app.run(
+        ssl_context=ssl_context(),
+        host=os.environ.get('FLASK_HOST', '127.0.0.1'),
+        port=os.environ.get('FLASK_PORT', 5050),
+        debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyJWT
 flask
 requests
+pyOpenSSL


### PR DESCRIPTION
Serve the app over SSL is the FLASK_SSL envvar exists.

Changed the Makefile from using the `flask run` CLI to running app.py
directly, app.py can now be run as a script and does app.run(). This was
necessary because [`flask run` doesn't support Werkzeug's `ssl_context`
argument](https://github.com/pallets/flask/blob/master/flask/cli.py#L444).