### PR TITLE
Don't embed Hypothesis on the login page

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -59,3 +59,15 @@
   of their best.
   </p>
 {% endblock %}
+
+{% block script %}
+<script>
+  {% if grant_token %}
+    var hypothesisGrantToken = "{{ grant_token }}";
+  {% else %}
+    var hypothesisGrantToken = null;
+  {% endif %}
+</script>
+<script src="/static/site.js"></script>
+<script src="{{ service_url }}/embed.js" async></script>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -28,14 +28,6 @@
     </main>
   </div>
 
-  <script>
-    {% if grant_token %}
-      var hypothesisGrantToken = "{{ grant_token }}";
-    {% else %}
-      var hypothesisGrantToken = null;
-    {% endif %}
-  </script>
-  <script src="/static/site.js"></script>
-  <script src="{{ service_url }}/embed.js" async defer></script>
+  {% block script %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
We were accidentally attempting to embed Hypothesis on the login page, which wasn't working because the `service_url` variable was undefined for that page.

Move the embed code script tags into the article template.