### PR TITLE
Handle "Sign up" request from client

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,7 @@ class LoginPage(MethodView):
 
 
 app.add_url_rule('/login', view_func=LoginPage.as_view('login'))
+app.add_url_rule('/signup', view_func=LoginPage.as_view('signup'))
 
 
 @app.route('/logout')

--- a/static/site.js
+++ b/static/site.js
@@ -1,16 +1,18 @@
 (function () {
-  const openLoginPopup = function openLoginPopup() {
+  const openPopup = (url) => {
     const width  = 400;
     const height = 400;
     const left   = window.screenX + ((window.innerWidth / 2)  - (width  / 2));
     const top    = window.screenY + ((window.innerHeight / 2) - (height / 2));
 
     window.open(
-      '/login',
+      url,
       'loginWindow',
       `left=${left},top=${top},width=${width},height=${height}`
     );
   };
+
+  const openLoginPopup = () => openPopup('/login');
 
   window.hypothesisConfig = function () {
     return {
@@ -19,6 +21,7 @@
         grantToken: hypothesisGrantToken,
         icon: 'https://openclipart.org/download/272629/sihouette-animaux-10.svg',
         onLoginRequest: openLoginPopup,
+        onSignupRequest: () => openPopup('/signup'),
       }],
     };
   };


### PR DESCRIPTION
Implement callback to handle "Sign up" link clicks in the client.

The '/signup' route is currently exactly the same as the '/login' route.
Having a different route makes it possible to verify that the correct
callback was invoked however.

Depends on https://github.com/hypothesis/client/pull/379