### PR TITLE
Apply branding to the sidebar

### DIFF
--- a/static/site.js
+++ b/static/site.js
@@ -16,6 +16,19 @@
 
   window.hypothesisConfig = function () {
     return {
+      branding: {
+        // Match the body's background color.
+        appBackgroundColor: '#ddd',
+
+        // Match the header's background and foreground colors.
+        accentColor: '#444',
+        ctaBackgroundColor: '#444',
+        ctaTextColor: 'white',
+
+        // Match the body text of the article.
+        annotationFontFamily: 'serif',
+        selectionFontFamily: 'serif',
+      },
       services: [{
         authority: 'partner.org',
         grantToken: hypothesisGrantToken,


### PR DESCRIPTION
Use the `branding` config settings for the sidebar to make the sidebar
better match the colors and typography of the content.

This provides an example and manual test for use of the sidebar's
theming / branding capabilities.

Created while testing https://github.com/hypothesis/client/pull/383