### PR TITLE
Fix the HYPOTHESIS_SERVICE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once you have a client ID and secret, you can run the test site as follows:
 
 ```
 pip install -r requirements.txt
-export HYPOTHESIS_SERVICE="http://127.0.0.1:5000" # Point to the local H service
+export HYPOTHESIS_SERVICE="http://localhost:5000" # Point to the local H service
 export HYPOTHESIS_AUTHORITY=$AUTHORITY  # Domain name used when registering publisher account
 export HYPOTHESIS_CLIENT_ID=$CLIENT_ID
 export HYPOTHESIS_CLIENT_SECRET=$CLIENT_SECRET


### PR DESCRIPTION
Fix the example HYPOTHESIS_SERVICE environment variable in the README to
be localhost not 127.0.0.1. This is consistent with the setup docs for h
and the client.

If you have the client configured to communicate with h on localhost,
but this publisher test site is configured with HYPOTHESIS_SERVICE set
to 127.0.0.1, then the client will get an "audience (aud) is invalid"
error from h when trying to make grant token request.

By changing HYPOTHESIS_SERVICE to localhost, the grant token request now
succeeds.