### PR TITLE
Fix crashing when logging in as admin

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,8 +32,10 @@ class LoginPage(MethodView):
         except HTTPError as ex:
             # FIXME: Make the service respond with an appropriate status code and
             # machine-readable error if the user account already exists
-            already_exists_err = 'user with email address {} already exists'.format(email)
-            if already_exists_err not in ex.response.content:
+            email_err = 'user with email address {} already exists'.format(email)
+            username_err = 'user with username {} already exists'.format(username)
+            content = ex.response.content
+            if email_err not in content and username_err not in content:
                 raise ex
 
         session['username'] = username


### PR DESCRIPTION
When you use h's users API to try to create a user that already exists
it sometimes returns a "username already exists" error message and
sometimes an "email already exists".

The publisher test site was failing to recognise the error when it was
"username already exists". Fix it to tolerate either error message.

A planned change to the h service is coming soon that will change the
error message to "username already exists, email already exists". The
code in this commit should work in that case too.