### PR TITLE
Fix example HYPOTHESIS_AUTHORITY in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once you have a client ID and secret, you can run the test site as follows:
 ```
 pip install -r requirements.txt
 export HYPOTHESIS_SERVICE="http://localhost:5000" # Point to the local H service
-export HYPOTHESIS_AUTHORITY=$AUTHORITY  # Domain name used when registering publisher account
+export HYPOTHESIS_AUTHORITY=partner.org  # Domain name used when registering publisher account
 export HYPOTHESIS_CLIENT_ID=$CLIENT_ID
 export HYPOTHESIS_CLIENT_SECRET=$CLIENT_SECRET
 make run


### PR DESCRIPTION
The commands that the README gives for creating the authclient etc in
the h db use the concrete value "partner.org". Change the example
HYPOTHESIS_AUTHORITY environment variable in the same README to use the
same "partner.org" value, rather than a $AUTHORITY placeholder.

I think that HYPOTHESIS_AUTHORITY actually _has_ to match the authority
used when creating the authclient etc in the db (partner.org). This just
makes the docs easier to follow by not making the reader have to figure
that out.