### PR TITLE
Use separate credentials for creating users and signing grant tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Publishers who just want to add the Hypothesis client to their pages and allow u
 
 First, you will need to create a couple of things on the Hypothesis service:
 
-1. A set of credentials (an "authclient") for managing annotations and users
-   associated with your domain.
+1. A set of credentials (a "client credentials" OAuth client) for managing users
+   and groups associated with your domain.
+
+2. A set of credentials (a "JWT bearer" OAuth client) for creating signed tokens that
+   the Hypothesis client can use to automatically log in as a particular user.
 
 2. A group associated with your domain to which users can post annotations.
    Annotations from this group will be displayed when the Hypothesis client
@@ -26,22 +29,28 @@ First, you will need to create a couple of things on the Hypothesis service:
 
 In [Hypothesis development environments](http://h.readthedocs.io/en/latest/developing/install/), you can do this using the `hypothesis` CLI tool:
 
-```sh
-# 1. Create an OAuth client which can manage annotations and users belonging
-# to partner.org
-./bin/hypothesis --dev authclient add --name Partner --authority partner.org
+1. Go to http://localhost:5000/admin/oauthclients and create a new OAuth client
+   with the type set to "client_credentials" and the authority set to "partner.org".
 
-# 2. Create an admin user for partner.org. This is needed because groups must
-# have a creator.
-./bin/hypothesis --dev user add --authority partner.org --username admin --email admin@localhost --password secret
+   This will give you a client ID and secret which can be used to create
+   accounts on the Hypothesis service via the API.
 
-# 3. Create the main group for annotations on partner.org
-./bin/hypothesis --dev groups add-publisher-group --authority partner.org --name Partner --creator admin
-```
+2. Create another OAuth client on the same page with the type set to
+   "jwt_bearer" and the authority also set to "partner.org"
 
-Step 1 will give you a client ID and secret which can be used to create accounts
-on the Hypothesis service via the API, and generate _grant tokens_ which can be
-used to identify the logged-in user to the Hypothesis client.
+   This will give you a client ID and secret which can be used to generate
+   _grant tokens_ which can be used to identify the logged-in user to the
+   Hypothesis client.
+
+3. Create an admin user for partner.org:
+   ```sh
+   ./bin/hypothesis --dev user add --authority partner.org --username admin --email admin@localhost --password secret
+   ```
+
+4. Create the main group for annotations on partner.org
+   ```sh
+   ./bin/hypothesis --dev groups add-publisher-group --authority partner.org --name Partner --creator admin
+   ```
 
 Once you have a client ID and secret, you can run the test site as follows:
 
@@ -51,6 +60,8 @@ export HYPOTHESIS_SERVICE="http://localhost:5000" # Point to the local H service
 export HYPOTHESIS_AUTHORITY=partner.org  # Domain name used when registering publisher account
 export HYPOTHESIS_CLIENT_ID=$CLIENT_ID
 export HYPOTHESIS_CLIENT_SECRET=$CLIENT_SECRET
+export HYPOTHESIS_JWT_CLIENT_ID=$JWT_CLIENT_ID
+export HYPOTHESIS_JWT_CLIENT_SECRET=$JWT_CLIENT_SECRET
 make run
 ```
 

--- a/app.py
+++ b/app.py
@@ -25,10 +25,12 @@ class LoginPage(MethodView):
         return render_template('login.html', **context)
 
     def post(self):
+        display_name = request.form['display_name']
         username = request.form['username']
         email = '{}@partner.org'.format(username)
         try:
-            hyp_client.create_account(username, email=email)
+            hyp_client.create_account(username, email=email,
+                                      display_name=display_name)
         except HTTPError as ex:
             # FIXME: Make the service respond with an appropriate status code and
             # machine-readable error if the user account already exists

--- a/app.py
+++ b/app.py
@@ -12,6 +12,8 @@ hypothesis_service = os.environ.get('HYPOTHESIS_SERVICE', 'http://localhost:5000
 hyp_client = HypothesisClient(authority=os.environ['HYPOTHESIS_AUTHORITY'],
                               client_id=os.environ['HYPOTHESIS_CLIENT_ID'],
                               client_secret=os.environ['HYPOTHESIS_CLIENT_SECRET'],
+                              jwt_client_id=os.environ['HYPOTHESIS_JWT_CLIENT_ID'],
+                              jwt_client_secret=os.environ['HYPOTHESIS_JWT_CLIENT_SECRET'],
                               service=hypothesis_service)
 
 

--- a/hypothesis.py
+++ b/hypothesis.py
@@ -19,7 +19,7 @@ class HypothesisClient(object):
         self.client_secret = client_secret
         self.service = service
 
-    def create_account(self, username, email):
+    def create_account(self, username, email, display_name=None):
         """
         Create an account on the Hypothesis service.
 
@@ -31,6 +31,7 @@ class HypothesisClient(object):
         data = {'authority': self.authority,
                 'username': username,
                 'email': email,
+                'display_name': display_name,
                 }
 
         rsp = requests.post(

--- a/hypothesis.py
+++ b/hypothesis.py
@@ -13,10 +13,13 @@ def _extract_domain(url):
 
 class HypothesisClient(object):
 
-    def __init__(self, client_id, client_secret, authority, service):
+    def __init__(self, client_id, client_secret, jwt_client_id,
+                 jwt_client_secret, authority, service):
         self.authority = authority
         self.client_id = client_id
         self.client_secret = client_secret
+        self.jwt_client_id = jwt_client_id
+        self.jwt_client_secret = jwt_client_secret
         self.service = service
 
     def create_account(self, username, email, display_name=None):
@@ -53,9 +56,9 @@ class HypothesisClient(object):
         now = datetime.datetime.utcnow()
         claims = {
             'aud': _extract_domain(self.service),
-            'iss': self.client_id,
+            'iss': self.jwt_client_id,
             'sub': 'acct:{}@{}'.format(username, self.authority),
             'nbf': now,
             'exp': now + datetime.timedelta(minutes=5),
         }
-        return jwt.encode(claims, self.client_secret, algorithm='HS256')
+        return jwt.encode(claims, self.jwt_client_secret, algorithm='HS256')

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,6 +5,7 @@
 {% block content %}
   <form method="POST" class="login-form js-login-form">
     <input type="text" name="username" placeholder="Username">
+    <input type="text" name="display_name" placeholder="Display name">
     <button>Sign up or Log in</button>
   </form>
 {% endblock %}


### PR DESCRIPTION
Update the publisher account test site to work again following the change in the service to use separate sets of credentials for creating users and for signing grant tokens.

I've also added an input field for setting the display names for new profiles to test out that functionality.