### PR TITLE
Support updating display names for existing users

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,9 @@ class LoginPage(MethodView):
             if email_err not in content and username_err not in content:
                 raise ex
 
+            if display_name:
+                hyp_client.update_account(username, display_name=display_name)
+
         session['username'] = username
         return redirect(url_for('login'))
 
@@ -59,7 +62,7 @@ def render_template_with_context(template):
     else:
         grant_token = None
 
-    hypothesis_api_url=hypothesis_service+'/api/'
+    hypothesis_api_url = hypothesis_service+'/api/'
 
     return render_template(
         template,
@@ -79,6 +82,7 @@ def logout():
 @app.route('/')
 def index():
     return render_template_with_context('article.html')
+
 
 @app.route('/help')
 def help():

--- a/hypothesis.py
+++ b/hypothesis.py
@@ -29,21 +29,32 @@ class HypothesisClient(object):
         This creates an account on the Hypothesis service, in the publisher's
         namespace, with the given `username` and `email`.
         """
-        auth = (self.client_id, self.client_secret)
-
         data = {'authority': self.authority,
                 'username': username,
                 'email': email,
                 'display_name': display_name,
                 }
+        return self._make_request('POST', 'users', data)
 
-        rsp = requests.post(
-            '{}/api/users'.format(self.service),
+    def update_account(self, username, email=None, display_name=None):
+        data = {}
+        if email is not None:
+            data['email'] = email
+        if display_name is not None:
+            data['display_name'] = display_name
+        return self._make_request('PATCH', 'users/{}'.format(username), data)
+
+    def _make_request(self, method, path, data):
+        auth = (self.client_id, self.client_secret)
+        rsp = requests.request(
+            method,
+            '{}/api/{}'.format(self.service, path),
             data=json.dumps(data),
             auth=auth,
             # Don't verify SSL certificates if posting to localhost.
             verify=urlparse(self.service).hostname != 'localhost')
         rsp.raise_for_status()
+        return rsp.json()
 
     def grant_token(self, username):
         """


### PR DESCRIPTION
If the user enters a new display name in the Log in / Sign up dialog,
then update the user account if it already exists when signing in.

This exercises the `/api/users/{username}` endpoint.