### PR TITLE
Fix installing tox

### DIFF
--- a/bin/install-python
+++ b/bin/install-python
@@ -41,5 +41,6 @@ do
     if ! "$(pyenv root)/versions/$python_version/bin/tox" --version > /dev/null 2>&1
     then
         "$(pyenv root)/versions/$python_version/bin/pip" install --quiet --disable-pip-version-check tox > /dev/null
+        pyenv rehash
     fi
 done < .python-version


### PR DESCRIPTION
Our scripting automatically installs tox in pyenv so you don't have to
install tox manually or system-wide. Unfortunately it wasn't working:
the installed tox doesn't appear on your PATH until you run a
`pyenv rehash`